### PR TITLE
Fix code scanning alert no. 5: Use of dangerous function

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -65,7 +65,7 @@ void sqlInjectionExample(const char *userInput) {
 void unsafeGetsExample() {
     char buffer[10];
     std::cout << "Enter a string: ";
-    gets(buffer); // Unsafe function, can cause buffer overflow
+    fgets(buffer, sizeof(buffer), stdin); // Safe function, prevents buffer overflow
     std::cout << "You entered: " << buffer << std::endl;
 }
 


### PR DESCRIPTION
Fixes [https://github.com/chenette/ghas-amd-demo/security/code-scanning/5](https://github.com/chenette/ghas-amd-demo/security/code-scanning/5)

To fix the problem, we should replace the `gets` function with `fgets`, which allows us to specify the maximum number of characters to read, thus preventing buffer overflow. The `fgets` function requires three arguments: the buffer to store the input, the maximum number of characters to read, and the input stream (in this case, `stdin`). This change will ensure that the buffer is not overflowed by limiting the input to the size of the buffer.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
